### PR TITLE
Refactor: Replace JIT references with Partner terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# jit-partner-api-specification
-Just in Time partner specification
+# partner-api-specification
+Partner API specification

--- a/checkout-and-first-payment-sequence-diagram.wsd
+++ b/checkout-and-first-payment-sequence-diagram.wsd
@@ -2,12 +2,12 @@
 
 actor User
 participant "Click App" as CA
-participant "MiniApp JIT" as miniJit
+participant "MiniApp Partner" as miniPartner
 participant "Click Evolution" as CE
 participant "Click BNPL" as CBNPL
 database "Click BNPL DB" as CBNPLDB
 participant "Click Acquiring" as CAcquiring
-participant "JIT backend" as jitBack
+participant "Partner backend" as partnerBack
 
 
 
@@ -19,78 +19,78 @@ CE -> CBNPL : Создать заказ(click_user_id, корзина)
 CBNPL -> CBNPL: Прескор клиента (Проверка на белый лист)
 CBNPL -> CBNPL: Проверка доступности параметры мерчанта 
 alt (отказ) Не прошел прескор 
-CBNPL --> CE: через JIT невозможно платить
+CBNPL --> CE: через Partner невозможно платить
 CE --> CA: Отказ
 CA --> User: Отказ / Может платить другим способом
 else (успешно) Прошел прескор
 CBNPL -> CBNPL : Сгенерировать checkout_id
-CBNPL -> jitBack : Создать заказ(checkout_id, click_user_id, корзина)
-jitBack -> jitBack : Сохранить(checkout_id, click_user_id) 
-jitBack -> jitBack: Проверка доступности лимита клиента
+CBNPL -> partnerBack : Создать заказ(checkout_id, click_user_id, корзина)
+partnerBack -> partnerBack : Сохранить(checkout_id, click_user_id) 
+partnerBack -> partnerBack: Проверка доступности лимита клиента
 
 alt (отказ) Не прошел проверку
-jitBack --> CBNPL: Не прошел проверку (отказ)
-CBNPL --> CE: через JIT невозможно платить
+partnerBack --> CBNPL: Не прошел проверку (отказ)
+CBNPL --> CE: через Partner невозможно платить
 CE --> CA: Отказ
 CA --> User: Отказ / Может платить другим способом
 
 else (успешно) Прошел проверку
-jitBack --> CBNPL: Прошел проверку (Вернуть планы)
+partnerBack --> CBNPL: Прошел проверку (Вернуть планы)
 CBNPL ->> CBNPLDB: Commit checkout_id
 CBNPL --> CE: Заказ создан, планы списаний
 CE --> CA: Заказ создан, планы списаний
 CA --> User: Виджет с планами
 
-== Оформление JIT ==
+== Оформление Partner ==
 
-User -> CA: Оформить JIT
-CA -> CE: payWithJIT(checkout_id, click_card_id, \nprovider_id)
+User -> CA: Оформить Partner
+CA -> CE: payWithPartner(checkout_id, click_card_id, \nprovider_id)
 
 CE -> CBNPL: /pay (checkout_id, click_card_id)
-CBNPL ->> miniJit: Редирект клиента в миниапп JIT
-miniJit --> User: Показывает лоадер
-miniJit -> jitBack: Запрос на подтверждение оформление JIT
-jitBack -> jitBack: Проверка наличие лимита клиента
+CBNPL ->> miniPartner: Редирект клиента в миниапп Partner
+miniPartner --> User: Показывает лоадер
+miniPartner -> partnerBack: Запрос на подтверждение оформление Partner
+partnerBack -> partnerBack: Проверка наличие лимита клиента
 alt (ошибка/отказ) Не прошел проверку
-jitBack --> miniJit: Показывает ответ в миниапп на миниапп | Ошибка при платеже \n+причина ошибки
-miniJit --> User: Ошибка при платеже / Показывает причину ошибки
+partnerBack --> miniPartner: Показывает ответ в миниапп на миниапп | Ошибка при платеже \n+причина ошибки
+miniPartner --> User: Ошибка при платеже / Показывает причину ошибки
 else (успешно) Можно провести первый платеж
-jitBack -> CBNPL: POST \n/api/bnpl/partner/v1/payment \nотправляет 0 сум
+partnerBack -> CBNPL: POST \n/api/bnpl/partner/v1/payment \nотправляет 0 сум
 CBNPL -> CAcquiring: Проведи платеж
 CAcquiring -> CAcquiring: Авторизация (click_user_id, click_card_id)
 CAcquiring -> CAcquiring: Проведет первый платеж
 alt Неизвестная ошибка(со статусом 500) при проведение платежа
 CAcquiring --> CBNPL: Ошибка при платеже \n+причина ошибки
-CBNPL --> jitBack: Отправит статус платежа в ответе \nОшибка при платеже \n+причина ошибки
-jitBack -> CBNPL: GET \n/api/bnpl/general/v2/payment/state
+CBNPL --> partnerBack: Отправит статус платежа в ответе \nОшибка при платеже \n+причина ошибки
+partnerBack -> CBNPL: GET \n/api/bnpl/general/v2/payment/state
 CBNPL -> CBNPL: Get payment status from click core system
-CBNPL --> jitBack: Payment status
+CBNPL --> partnerBack: Payment status
 alt ошибка(со статусом 500)
-jitBack --> miniJit: Показывает ответ в миниапп на миниапп | Ошибка при платеже \n+причина ошибки
-miniJit --> User: Ошибка при платеже / Показывает причину ошибки
+partnerBack --> miniPartner: Показывает ответ в миниапп на миниапп | Ошибка при платеже \n+причина ошибки
+miniPartner --> User: Ошибка при платеже / Показывает причину ошибки
 else status = 2 (со статусом 200)
-jitBack --> miniJit: Показывает ответ в миниапп | JIT успешно оформлен
-miniJit --> User: JIT успешно оформлен
+partnerBack --> miniPartner: Показывает ответ в миниапп | Partner успешно оформлен
+miniPartner --> User: Partner успешно оформлен
 end
 else Ошибка(со статусом 200) при проведение платежа
 CAcquiring --> CBNPL: Ошибка при платеже \n+причина ошибки
-CBNPL --> jitBack: Отправит статус платежа в ответе \nОшибка при платеже \n+причина ошибки
-jitBack -> CBNPL: GET \n/api/bnpl/general/v2/payment/state
+CBNPL --> partnerBack: Отправит статус платежа в ответе \nОшибка при платеже \n+причина ошибки
+partnerBack -> CBNPL: GET \n/api/bnpl/general/v2/payment/state
 CBNPL -> CBNPL: Get payment status from click core system
-CBNPL --> jitBack: Payment status
+CBNPL --> partnerBack: Payment status
 alt ошибка(со статусом 500)
-jitBack --> miniJit: Показывает ответ в миниапп на миниапп | Ошибка при платеже \n+причина ошибки
-miniJit --> User: Ошибка при платеже / Показывает причину ошибки
+partnerBack --> miniPartner: Показывает ответ в миниапп на миниапп | Ошибка при платеже \n+причина ошибки
+miniPartner --> User: Ошибка при платеже / Показывает причину ошибки
 else status = 2 (со статусом 200)
-jitBack --> miniJit: Показывает ответ в миниапп | JIT успешно оформлен
-miniJit --> User: JIT успешно оформлен
+partnerBack --> miniPartner: Показывает ответ в миниапп | Partner успешно оформлен
+miniPartner --> User: Partner успешно оформлен
 end
 else Платеж проведен успешно
 CAcquiring --> CBNPL: Платеж проведен
 CBNPL -> CBNPLDB: Сохранить платеж
-CBNPL --> jitBack: Отправит статус платежа в ответе
-jitBack --> miniJit: Показывает ответ в миниапп | JIT успешно оформлен
-miniJit --> User: JIT успешно оформлен
+CBNPL --> partnerBack: Отправит статус платежа в ответе
+partnerBack --> miniPartner: Показывает ответ в миниапп | Partner успешно оформлен
+miniPartner --> User: Partner успешно оформлен
 
 end
 end

--- a/click-partner-api.yml
+++ b/click-partner-api.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  title: CLICK-JIT BNPL API specification
+  title: CLICK-Partner BNPL API specification
   description: >
     Универсальные API для управление BNPL
   version: "1.0.4"
@@ -15,16 +15,16 @@ security:
 
 
 tags:
-  - name: CLICK-JIT API
-    description: Универсальные API для BNPL / JIT операций
+  - name: CLICK-Partner API
+    description: Универсальные API для BNPL / Partner операций
 
 paths:
   /api/bnpl/partner/v1/payment:
     post:
       tags:
-        - CLICK-JIT API
+        - CLICK-Partner API
       summary: Создание платежа
-      description: Создает новый платеж через JIT. Поля isFee и isPenalty являются опциональными. Эти поля нельзя отправить вместе в одном запросе.
+      description: Создает новый платеж через Partner. Поля isFee и isPenalty являются опциональными. Эти поля нельзя отправить вместе в одном запросе.
       requestBody:
         required: true
         content:
@@ -62,7 +62,7 @@ paths:
   /api/bnpl/partner/v1/payment/ofd-links:
     get:
       tags:
-        - CLICK-JIT API
+        - CLICK-Partner API
       summary: Возврат платежи с OFD ссылками
       description: Возврат платежи с OFD ссылками
       parameters:
@@ -99,7 +99,7 @@ paths:
   /api/bnpl/partner/v1/accounts/list:
     get:
       tags:
-        - CLICK-JIT API
+        - CLICK-Partner API
       summary: Список карт клиента
       description: Возвращает список доступных карт клиента.
       parameters:
@@ -161,9 +161,9 @@ paths:
   /api/bnpl/partner/v1/application/complete:
     patch:
       tags:
-        - CLICK-JIT API
+        - CLICK-Partner API
       summary: Обновление статуса заявки
-      description: Обновляет статус заявки BNPL / JIT.
+      description: Обновляет статус заявки BNPL / Partner.
       requestBody:
         required: true
         content:
@@ -195,7 +195,7 @@ paths:
   /api/bnpl/general/v2/payment/state:
     get:
       tags:
-        - CLICK-JIT API
+        - CLICK-Partner API
       summary: Получить состояние.
       description: Получить состояние платежа по ключу инедепонтенсности из ядра (CLICK core DB)
       parameters:
@@ -252,7 +252,7 @@ paths:
   /api/bnpl/general/v2/payment/specific/refund:
     patch:
       tags:
-        - CLICK-JIT API
+        - CLICK-Partner API
       summary: Возврат платежа по payment ID
       description: Возврат платежа по payment ID.
       requestBody:

--- a/partner-click-api.yml
+++ b/partner-click-api.yml
@@ -1,8 +1,8 @@
 openapi: "3.0.0"
 info:
-  title: CLICK-JIT BNPL API specification
+  title: CLICK Partner BNPL API specification
   description: >
-    Универсальные API для управление BNPL (JIT-CLICK)
+    Универсальные API для управление BNPL (Partner-CLICK)
   version: "1.0.4"
 
 servers:
@@ -13,14 +13,14 @@ security:
   - OAuth2: []
 
 tags:
-  - name: JIT-CLICK API
-    description: Универсальные API для BNPL / JIT операций
+  - name: Partner-CLICK API
+    description: Универсальные API для BNPL / Partner операций
 
 paths:
   /click/api/v1/checkout-with-plans/get:
     post:
       tags:
-        - JIT-CLICK API
+        - Partner-CLICK API
       summary: Получить планы списаний
       description: Отправка запрос на прескор клиента и получение планы списаний
       requestBody:
@@ -35,7 +35,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/jitPlanSchema'
+                $ref: '#/components/schemas/partnerPlanSchema'
         "400":
           description: Default Error Response
           content:
@@ -46,7 +46,7 @@ paths:
   /click/api/v1/refund/create:
     post:
       tags:
-        - JIT-CLICK API
+        - Partner-CLICK API
       summary: Получить планы списаний
       description: Отправка запрос на прескор клиента и получение планы списаний
       parameters:
@@ -92,7 +92,7 @@ paths:
   /click/api/v1/refund/info:
     post:
       tags:
-        - JIT-CLICK API
+        - Partner-CLICK API
       summary: Получить планы списаний
       description: Отправка запрос на прескор клиента и получение планы списаний
       requestBody:
@@ -249,7 +249,7 @@ components:
                     description: Общая сумма товаров
                     example: "20000.00"
 
-    jitPlanSchema:
+    partnerPlanSchema:
       required:
       - plans
       type: object
@@ -280,16 +280,16 @@ components:
                 type: string
                 enum:
                 - full_payment
-                - base_jit
-                - long_jit
+                - base_partner
+                - long_partner
                 - credit_full_payment
                 - pay_full_payment
                 - pay_later
-                - base_jit_uz
+                - base_partner_uz
               constructor:
                 description: Тип конструктора оплаты
                 type: string
-                example: "jit_10_days_afterpay_uz"
+                example: "partner_10_days_afterpay_uz"
               payments:
                 description: Детали платежа
                 type: array

--- a/refund-payment-sequence-diagram.wsd
+++ b/refund-payment-sequence-diagram.wsd
@@ -4,37 +4,37 @@ actor ARM
 participant "Click BNPL service" as CBNPL
 database "Click BNPL DB" as CBNPLDB
 participant "Click core" as cc
-participant "JIT backend" as jitBack
+participant "Partner backend" as partnerBack
 
 == Создание процеccа возврат денег BNPL ==
 
 ARM -> CBNPL: Запрос на возврат денег \nPATCH \n/api/bnpl/v1/internal/payment/refund \n"paymentId"
 CBNPL -> CBNPLDB: Создаёт запись со статусом "draft"
-CBNPL -> jitBack: POST \n/click/api/v1/refund/create \n"checkout_id"
-jitBack -> jitBack: Создать запись для возвратов \nСоздается со статусом "draft"
-/note over jitBack
+CBNPL -> partnerBack: POST \n/click/api/v1/refund/create \n"checkout_id"
+partnerBack -> partnerBack: Создать запись для возвратов \nСоздается со статусом "draft"
+/note over partnerBack
 Этот запрос триггерит 
 цикла в котором отменяется
 все платежи которые 
 до этого проводили
 end note
-jitBack --> CBNPL: Возвращает в ответе "refund_id"
+partnerBack --> CBNPL: Возвращает в ответе "refund_id"
 CBNPL -> CBNPLDB: Обновляет запись - статус "processing"
 CBNPL --> ARM: Запрос принят на обработку
 
 
-== Процеcc возврат денег на стороне JIT ==
+== Процеcc возврат денег на стороне Partner ==
 
-jitBack -> jitBack: Получает все совершённые платежи по "checkout_id"
-jitBack -> jitBack: Обновляет статус возврата на "processing"
+partnerBack -> partnerBack: Получает все совершённые платежи по "checkout_id"
+partnerBack -> partnerBack: Обновляет статус возврата на "processing"
 loop Все платежи отменены
-jitBack -> CBNPL: PATCH \n/api/bnpl/general/v1/payment/specific/refund
+partnerBack -> CBNPL: PATCH \n/api/bnpl/general/v1/payment/specific/refund
 CBNPL -> cc: Запрос на отмену платежа по "payment_id"
 cc -> cc: Отменяет платежа
 cc --> CBNPL: Ответ со статусом
-CBNPL --> jitBack: "refundCompleted", "statusDescription"
+CBNPL --> partnerBack: "refundCompleted", "statusDescription"
 end
-jitBack -> jitBack: Обновляет статус возврата на "approved"
+partnerBack -> partnerBack: Обновляет статус возврата на "approved"
 
 == Процеcc возврат денег на стороне CLICK ==
 
@@ -45,8 +45,8 @@ jitBack -> jitBack: Обновляет статус возврата на "appro
 (каждые 10 сек)
 end note
 loop refund_status == approved
-CBNPL -> jitBack: POST \n/click/api/v1/refund/info \n"refund_id"
-jitBack --> CBNPL: Возвращает в ответе "status"
+CBNPL -> partnerBack: POST \n/click/api/v1/refund/info \n"refund_id"
+partnerBack --> CBNPL: Возвращает в ответе "status"
 
 end
 CBNPL -> CBNPL: Получил ответ что статус возвратов = "approved"


### PR DESCRIPTION
- Renamed files: jit-click-api.yml -> partner-click-api.yml, click-jit-api.yml -> click-partner-api.yml
- Updated all API tags from JIT-CLICK/CLICK-JIT to Partner-CLICK/CLICK-Partner
- Replaced schema names: jitPlanSchema -> partnerPlanSchema
- Updated product types: base_jit -> base_partner, long_jit -> long_partner
- Modified sequence diagrams: JIT backend -> Partner backend, MiniApp JIT -> MiniApp Partner
- Updated README.md to reflect Partner API specification

This makes the API specification universal for all partners, not specific to JIT product.